### PR TITLE
stable-python-version to python-version

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -45,7 +45,7 @@ jobs:
           uname -a
           df -h
           ulimit -a
-          echo "Using Python ${{ steps.get-python-version.outputs.stable-python-version }}"
+          echo "Using Python ${{ steps.get-python-version.outputs.python-version }}"
       
       - name: Set up Python ${{ steps.get-python-version.outputs.python-version }}
         uses: actions/setup-python@v3


### PR DESCRIPTION
Tiny thing, was just looking at the usage of the python version setting up, turns out one of the steps as using the wrong environment variable.