### PR TITLE
Patch CI package management

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -148,7 +148,8 @@ jobs:
           environment-file: docs/requirements.yaml
           add-pip-as-python-dependency: true
           architecture: x64
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
+          uses-mamba: true
           channels: conda-forge, defaults
           activate-environment: cookiecutter-mdakit-docs
           auto-update-conda: true

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,3 +20,6 @@ The rules for this file:
 - Lily Wang \<@lilyminium\>
 - Irfan Alibay \<@IAlibay\>
 - Fiona Naughton \<@fiona-naughton\>
+
+**2023**
+- Ian Kenney \<@ianmkenney\>


### PR DESCRIPTION
- Workaround proposed in https://github.com/conda-incubator/setup-miniconda/issues/274#issue-1531425010
- Set to use mamba over conda
