### PR TITLE
Use Mambaforge in the generated project

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -149,7 +149,7 @@ jobs:
           add-pip-as-python-dependency: true
           architecture: x64
           miniforge-variant: Mambaforge
-          uses-mamba: true
+          use-mamba: true
           channels: conda-forge, defaults
           activate-environment: cookiecutter-mdakit-docs
           auto-update-conda: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The rules for this file:
 
 ### Fixed
 <!-- Bug fixes -->
+- Generated template shipped with broken CI options (PR #41)
 
 ### Changed
 <!-- Changes in existing functionality -->

--- a/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
@@ -73,7 +73,8 @@ jobs:
         add-pip-as-python-dependency: true
         architecture: x64
 {% if cookiecutter.__dependency_source == 'conda-forge' %}
-        mamba-version: "*"
+        miniforge-variant: Mambaforge
+        use-mamba: true
         channels: conda-forge, defaults
 {% elif cookiecutter.__dependency_source == 'anaconda' %}
         channels: defaults


### PR DESCRIPTION
Fixes #37 

Changes made in this Pull Request:
 - The project template CI was changed to use Mambaforge so it doesn't fail by default


PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [x] CHANGELOG.md updated?
 - [x] AUTHORS.md updated?
 - [x] Issue raised/referenced?
