### PR TITLE
Add cookiecutter 2+ to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The rules for this file:
 
 ### Added
 <!-- New added features -->
+- Cookiecutter version dependency (Issue #33, PR #46)
 - Configuration files for external hooks (PR #9)
 - Overhaul cookiecutter CI (PR #10, #26)
 - Overhaul cookie CI (PR #7, #28)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ packages based on MDAnalysis. Starting repositories can be created from this tem
 ## Requirements
 
 * Python 3.8+
-* [Cookiecutter](http://cookiecutter.readthedocs.io/en/latest/installation.html)
+* [Cookiecutter](http://cookiecutter.readthedocs.io/en/latest/installation.html) 2+
 * [Git](https://git-scm.com/)
 
 ## Usage


### PR DESCRIPTION
Fixes #33

Changes made in this Pull Request:
 - Add "2+" after cookiecutter in README


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG.md updated?
 - [ ] AUTHORS.md updated?
 - [x] Issue raised/referenced?
