### PR TITLE
sys.path needs to be modified before any imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The rules for this file:
 - Remove redundant code of conduct document (Issue #42)
 - Generated template shipped with broken CI options (PR #41)
 - Added MDA install for CI pylint check (Issue #47, PR #48)
+- Cookiecutter docs configuration sys.path change must come before import (Issue #60)
 
 ### Changed
 <!-- Changes in existing functionality -->

--- a/{{cookiecutter.repo_name}}/docs/source/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/source/conf.py
@@ -13,10 +13,11 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
 # Incase the project was not installed
-import {{cookiecutter.repo_name}}
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../..'))
+import {{cookiecutter.repo_name}}
+
 
 
 # -- Project information -----------------------------------------------------

--- a/{{cookiecutter.repo_name}}/docs/source/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/source/conf.py
@@ -16,7 +16,7 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../..'))
-import {{cookiecutter.repo_name}}
+import {{cookiecutter.repo_name}}  # noqa
 
 
 


### PR DESCRIPTION
`sys.path` was modified after the attempted import. As far as I'm aware, there is no reason for this ordering of statements. Fixes #60 