### PR TITLE
Remove Python 3.8 from cookiecutter build matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The rules for this file:
 - Remove redundant code of conduct document (Issue #42)
 - Generated template shipped with broken CI options (PR #41)
 - Added MDA install for CI pylint check (Issue #47, PR #48)
+- Removed Python 3.8 from cookiecutter build matrix (Issue #59)
 
 ### Changed
 <!-- Changes in existing functionality -->

--- a/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
@@ -42,7 +42,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [macOS-latest, ubuntu-latest, windows-latest]
-          python-version: ["3.8", "3.9", "3.10"]
+          python-version: ["3.9", "3.10"]
           mdanalysis-version: ["latest", "develop"]
 
     steps:


### PR DESCRIPTION
Fixes #59

Changes made in this Pull Request:
 - Removed Python 3.8 from the cookiecutter build matrix
