### PR TITLE
Propagate kwargs to AnalysisBase

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,3 +23,4 @@ The rules for this file:
 
 **2023**
 - Ian Kenney \<@ianmkenney\>
+- Rocco Meli \<@RMeli\>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The rules for this file:
 
 ### Fixed
 <!-- Bug fixes -->
+- Propagate `**kwargs` to `AnalysisBase` (PR #66)
 - Remove redundant code of conduct document (Issue #42)
 - Generated template shipped with broken CI options (PR #41)
 - Added MDA install for CI pylint check (Issue #47, PR #48)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/analysis/{{cookiecutter.template_analysis_class.lower()}}.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/analysis/{{cookiecutter.template_analysis_class.lower()}}.py
@@ -61,7 +61,7 @@ class {{ cookiecutter.template_analysis_class }}(AnalysisBase):
         **kwargs
     ):
         # the below line must be kept to initialize the AnalysisBase class!
-        super().__init__(universe_or_atomgroup.trajectory, **kwards)
+        super().__init__(universe_or_atomgroup.trajectory, **kwargs)
         # after this you will be able to access `self.results`
         # `self.results` is a dictionary-like object
         # that can should used to store and retrieve results

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/analysis/{{cookiecutter.template_analysis_class.lower()}}.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/analysis/{{cookiecutter.template_analysis_class.lower()}}.py
@@ -61,7 +61,7 @@ class {{ cookiecutter.template_analysis_class }}(AnalysisBase):
         **kwargs
     ):
         # the below line must be kept to initialize the AnalysisBase class!
-        super().__init__(universe_or_atomgroup.trajectory)
+        super().__init__(universe_or_atomgroup.trajectory, **kwards)
         # after this you will be able to access `self.results`
         # `self.results` is a dictionary-like object
         # that can should used to store and retrieve results


### PR DESCRIPTION
Shouldn't `**kwargs` be propagated to AnalysisBase? Since users might adapt the provided code snippet, it might be worth adding.

Changes made in this Pull Request:
 - Propagate kwargs to AnalysisBase


PR Checklist
------------
 - [x] CHANGELOG.md updated?
 - [x] AUTHORS.md updated?
