### PR TITLE
Exclude unreachable code from coverage

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -8,6 +8,10 @@ omit =
     # Omit generated versioneer
     {{cookiecutter.package_name}}/_version.py
 
+[coverage:report]
+exclude_also =
+    if TYPE_CHECKING:
+
 [isort]
 multi_line_output = 3
 include_trailing_comma = True


### PR DESCRIPTION
Changes made in this Pull Request:
 - Exclude unreachable code from code coverage

`TYPE_CHECKING` is always `False` at runtime, therefore the following needlessly decreases code coverage:

https://github.com/MDAnalysis/cookiecutter-mdakit/blob/cb1fd3dd602ff4f7330d30f24d8ce83f875875aa/%7B%7Bcookiecutter.repo_name%7D%7D/%7B%7Bcookiecutter.package_name%7D%7D/analysis/%7B%7Bcookiecutter.template_analysis_class.lower()%7D%7D.py#L13-L14

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG.md updated?
 - [ ] AUTHORS.md updated?
 - [ ] Issue raised/referenced?
