### PR TITLE
Adding Python 3.11 to build matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The rules for this file:
 - Overhaul cookie CI (PR #7, #28)
 - New packaging standard (PR #6)
 - Analysis template (PR #19)
+- Added Python 3.11 to cookiecutter build matrix (Issue #68)
 
 
 ### Fixed

--- a/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
@@ -42,7 +42,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [macOS-latest, ubuntu-latest, windows-latest]
-          python-version: ["3.9", "3.10"]
+          python-version: ["3.9", "3.10", "3.11"]
           mdanalysis-version: ["latest", "develop"]
 
     steps:


### PR DESCRIPTION
Fixes #68 

Changes made in this Pull Request:
 - Added Python 3.11 to the cookiecutter build matrix