### PR TITLE
Bump minimum Python version in line with CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The rules for this file:
 
 ### Fixed
 <!-- Bug fixes -->
+- Bump minimum Python version to 3.9 in line with CI build matrix (#70)
 - Propagate `**kwargs` to `AnalysisBase` (PR #66)
 - Exclude `if TYPE_CHECKING:` branches from code coverage report (PR #67)
 - Remove redundant code of conduct document (Issue #42)

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
     {{ "{" }}name = "{{cookiecutter.author_name}}", email = "{{cookiecutter.author_email}}"{{ "}" }},
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "MDAnalysis>=2.0.0",
 ]

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -44,7 +44,7 @@ setup(
     # Customize MANIFEST.in if the general case does not suit your needs
     # Comment out this line to prevent the files from being packaged with your software
     include_package_data=True,
-    python_requires=">=3.8",          # Python version restrictions
+    python_requires=">=3.9",          # Python version restrictions
     # Allows `setup.py test` to work correctly with pytest
     setup_requires=[] + pytest_runner,
     # Required packages, pulls from pip if needed


### PR DESCRIPTION
Changes made in this Pull Request:
 - Bump minimum Python version in line with CI

PR #62 removed Python 3.8 from the cookiecutter build matrix. I think the minimum Python version should be updated too (so that all supported versions are tested). Users can of course change this if they want to, pinning the version of MDAnalysis accordingly.

PR Checklist
------------
 - [x] CHANGELOG.md updated?
