### PR TITLE
Define minimum Python version in a single place

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -26,5 +26,6 @@
         "Dependencies from pip only (no conda)": "pip"
     },
     "__dependency_source": "{{ cookiecutter._dependency_source_keys[cookiecutter.dependency_source] }}",
-    "_copy_without_render": []
+    "_copy_without_render": [],
+    "_min_py_ver": "3.9"
 }

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
     {{ "{" }}name = "{{cookiecutter.author_name}}", email = "{{cookiecutter.author_email}}"{{ "}" }},
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">={{ cookiecutter._min_py_ver }}"
 dependencies = [
     "MDAnalysis>=2.0.0",
 ]

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -44,7 +44,7 @@ setup(
     # Customize MANIFEST.in if the general case does not suit your needs
     # Comment out this line to prevent the files from being packaged with your software
     include_package_data=True,
-    python_requires=">=3.9",          # Python version restrictions
+    python_requires=">={{ cookiecutter._min_py_ver }}",          # Python version restrictions
     # Allows `setup.py test` to work correctly with pytest
     setup_requires=[] + pytest_runner,
     # Required packages, pulls from pip if needed


### PR DESCRIPTION
https://github.com/MDAnalysis/cookiecutter-mdakit/pull/70#issuecomment-1556115241

Not an automation, but facilitates the update of the minimum Python version. 

I wonder if the same should be done for all other packages too?

```
"_ver": {
  "python": {
    "min": "3.9"
  },
  "mdanalysis": {
    "min": "2.0.0"
  }
  # and so on...
}
```