### PR TITLE
fix intersphinx_mapping

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/source/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/source/conf.py
@@ -176,6 +176,6 @@ texinfo_documents = [
 
 # -- Extension configuration -------------------------------------------------
 intersphinx_mapping = {
-    'https://docs.python.org/3/': None,
-    'https://docs.mdanalysis.org/stable/': None,
+    'python': ('https://docs.python.org/3/', None),
+    'mdanalysis': ('https://docs.mdanalysis.org/stable/', None),
 }


### PR DESCRIPTION
Follow-up from https://github.com/MDAnalysis/mdaencore/pull/18 and https://github.com/MDAnalysis/mdaencore/issues/16

The old intersphinx_mapping use is deprecated, this switches to the new dict + tuple approach.