### PR TITLE
Don't run CI on mdanalysis latest + latest python

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
@@ -27,8 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       stable-python-version: {{ "${{ steps.get-compatible-python.outputs.stable-python }}" }}
-      latest-python: {{ '${{ setups.get-compatible-python.outputs.latest-python }}" }}
-      python-matrix: {{ '${{ steps.get-compatible-python.outputs.python-versions }}' }}
+      latest-python: {{ "${{ setups.get-compatible-python.outputs.latest-python }}" }}
+      python-matrix: {{ "${{ steps.get-compatible-python.outputs.python-versions }}" }}
     steps:
       - uses: actions/setup-python@v4
         with:

--- a/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       stable-python-version: {{ "${{ steps.get-compatible-python.outputs.stable-python }}" }}
+      latest-python: {{ '${{ setups.get-compatible-python.outputs.latest-python }}" }}
       python-matrix: {{ '${{ steps.get-compatible-python.outputs.python-versions }}' }}
     steps:
       - uses: actions/setup-python@v4
@@ -46,9 +47,12 @@ jobs:
           os: [macOS-latest, ubuntu-latest, windows-latest]
           python-version: {% raw %}${{ fromJSON(needs.environment-config.outputs.python-matrix) }}{% endraw %}
           mdanalysis-version: ["latest", "develop"]
+          exclude:
+            - mdanalysis-version: "latest"
+              python-version: {% raw %}"${{ fromJSON(needs.environment-config.outputs.latest-python-version) }}"{% endraw %}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Build information
       run: |
@@ -129,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -155,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python {{ '${{ needs.environment-config.outputs.stable-python-version }}' }}
       uses: actions/setup-python@v4

--- a/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
@@ -27,7 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       stable-python-version: {{ "${{ steps.get-compatible-python.outputs.stable-python }}" }}
-      latest-python: {{ "${{ setups.get-compatible-python.outputs.latest-python }}" }}
       python-matrix: {{ "${{ steps.get-compatible-python.outputs.python-versions }}" }}
     steps:
       - uses: actions/setup-python@v4
@@ -36,6 +35,8 @@ jobs:
 
       - id: get-compatible-python
         uses: MDAnalysis/mdanalysis-compatible-python@main
+        with:
+          release: "latest"
 
   main-tests:
     if: "github.repository == '{{ cookiecutter.github_host_account }}/{{ cookiecutter.repo_name }}'"
@@ -47,9 +48,6 @@ jobs:
           os: [macOS-latest, ubuntu-latest, windows-latest]
           python-version: {% raw %}${{ fromJSON(needs.environment-config.outputs.python-matrix) }}{% endraw %}
           mdanalysis-version: ["latest", "develop"]
-          exclude:
-            - mdanalysis-version: "latest"
-              python-version: {% raw %}"${{ fromJSON(needs.environment-config.outputs.latest-python-version) }}"{% endraw %}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #92 (I think)

This might need some discussion.

Currently CI will run all the versions that the develop version of MDAnalysis will support.

This will cause failures when it attempts to run a brand new version of Python that the last release of MDA doesn't support (for example Python 3.12 + MDAnalysis 2.6.1).

There are two options I can see out of this:

1. We just don't run the latest version of Python against the last release of MDAnalysis - this fix does this.
2. We split up the test step into two, a latest & development step. On the latest step we take the output of mdanalysis-compatible-python with the latest version of MDA, and the development the same python matrix as what we call currently.
  - Note: This will need a bit of work to grab out the latest version of MDA, it's not the end of the world but I'm unlikely to have much time to do this in the next couple of days given work requirements (indeed this is the last thing I can do today since I have to go back to my day job).

In all cases we're going to have to go to the MDAnalysis cookie-cutter using repos and fix this workflow, because right now all their CI is failing.



PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG.md updated?
 - [ ] AUTHORS.md updated?
 - [ ] Issue raised/referenced?
