### PR TITLE
pypi_check shouldn't call setup.py - switch to pipx run build

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
@@ -166,11 +166,11 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install setuptools cython numpy twine
+        pip install pipx twine
 
     - name: Build package
       run: |
-        python setup.py sdist
+        python -m pipx run build --sdist
 
     - name: Check package build
       run: |


### PR DESCRIPTION
I'm not sure why CI was still green after that one 🙀 