### PR TITLE
[WIP] ModuleNotFound Error Fix

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,3 +25,6 @@ The rules for this file:
 - Ian Kenney \<@ianmkenney\>
 - Rocco Meli \<@RMeli\>
 - Oliver Beckstein \<@orbeckst\>
+
+**2024**
+- Lawson Woods \<@ljwoods2\>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,11 @@ The rules for this file:
 - ianmkenney
 - RMeli
 - orbeckst
+- ljwoods2
 
 ### Added
 <!-- New added features -->
+- Fixed ModuleNotFound after installation (Issue #113, PR #115) 
 - Add black configurartion to `pyproject.toml` (Issue #73, PR #75)
 - Cookiecutter version dependency (Issue #33, PR #46)
 - Configuration files for external hooks (PR #9)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,7 +1,8 @@
 import pytest
 
 from .utils import CookiecutterMDAKit, DependencyType
-
+import subprocess
+import sys
 
 class TestAnalysis:
 
@@ -69,3 +70,15 @@ def test_write_outputs(
         output_directory=str(output_directory.resolve()),
     )
     kitter.run()
+
+def test_install_and_import(tmpdir):
+    with tmpdir.as_cwd():
+        kit = CookiecutterMDAKit(template_analysis_class="MyAnalysisClass")
+        kit.run()
+        result = subprocess.run([sys.executable, "-m", "pip", "install", "-e", "./test-mda-kit"], capture_output=True, text=True)
+        if result.returncode != 0:
+            pytest.fail(f"Failed to install: {result.stderr}")
+        try:
+            import test_mdakit_package
+        except ImportError as e:
+            pytest.fail(f"Failed to import 'test_mdakit_package': {e}")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -71,11 +71,14 @@ def test_write_outputs(
     )
     kitter.run()
 
+
 def test_install_and_import(tmpdir):
     with tmpdir.as_cwd():
         kit = CookiecutterMDAKit(template_analysis_class="MyAnalysisClass")
         kit.run()
-        result = subprocess.run([sys.executable, "-m", "pip", "install", "-e", "./test-mda-kit"], capture_output=True, text=True)
+        result = subprocess.run([sys.executable,
+                                  "-m", "pip", "install", "-e", "./test-mda-kit"],
+                                    capture_output=True, text=True)
         if result.returncode != 0:
             pytest.fail(f"Failed to install: {result.stderr}")
         try:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -70,31 +70,3 @@ def test_write_outputs(
         output_directory=str(output_directory.resolve()),
     )
     kitter.run()
-
-
-def test_install_and_import(tmpdir):
-    with tmpdir.as_cwd():
-        kit = CookiecutterMDAKit(template_analysis_class="MyAnalysisClass")
-        kit.run()
-        result = subprocess.run(["python", "-m", "pip", "install",
-                                 "-e", "./test-mda-kit"],
-                                capture_output=True, text=True)
-        if result.returncode != 0:
-            pytest.fail(f"Failed to install: {result.stderr}")
-        try:
-            import test_mdakit_package
-        except ImportError as e:
-            pytest.fail(f"Failed to import 'test_mdakit_package': {e}")
-
-def test_gh_actions_debug_python_env(tmpdir):
-    with tmpdir.as_cwd():
-        
-        result = subprocess.run(["python", "-m", "pip", "install",
-                                 "mdanalysistests"],
-                                capture_output=True, text=True)
-        if result.returncode != 0:
-            pytest.fail(f"Failed to install: {result.stderr}")
-        try:
-            import MDAnalysisTests
-        except ImportError as e:
-            pytest.fail(f"Failed to import 'MDAnalysisTests': {e}")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -77,9 +77,9 @@ def test_install_and_import(tmpdir):
         kit = CookiecutterMDAKit(template_analysis_class="MyAnalysisClass")
         kit.run()
         result = subprocess.run([sys.executable,
-                                 "-m", "pip", "install", 
+                                 "-m", "pip", "install",
                                  "-e", "./test-mda-kit"],
-                                 capture_output=True, text=True)
+                                capture_output=True, text=True)
         if result.returncode != 0:
             pytest.fail(f"Failed to install: {result.stderr}")
         try:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -76,8 +76,7 @@ def test_install_and_import(tmpdir):
     with tmpdir.as_cwd():
         kit = CookiecutterMDAKit(template_analysis_class="MyAnalysisClass")
         kit.run()
-        result = subprocess.run([sys.executable,
-                                 "-m", "pip", "install",
+        result = subprocess.run(["python", "-m", "pip", "install",
                                  "-e", "./test-mda-kit"],
                                 capture_output=True, text=True)
         if result.returncode != 0:
@@ -86,3 +85,16 @@ def test_install_and_import(tmpdir):
             import test_mdakit_package
         except ImportError as e:
             pytest.fail(f"Failed to import 'test_mdakit_package': {e}")
+
+def test_gh_actions_debug_python_env(tmpdir):
+    with tmpdir.as_cwd():
+        
+        result = subprocess.run(["python", "-m", "pip", "install",
+                                 "mdanalysistests"],
+                                capture_output=True, text=True)
+        if result.returncode != 0:
+            pytest.fail(f"Failed to install: {result.stderr}")
+        try:
+            import MDAnalysisTests
+        except ImportError as e:
+            pytest.fail(f"Failed to import 'MDAnalysisTests': {e}")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -77,8 +77,9 @@ def test_install_and_import(tmpdir):
         kit = CookiecutterMDAKit(template_analysis_class="MyAnalysisClass")
         kit.run()
         result = subprocess.run([sys.executable,
-                                  "-m", "pip", "install", "-e", "./test-mda-kit"],
-                                    capture_output=True, text=True)
+                                 "-m", "pip", "install", 
+                                 "-e", "./test-mda-kit"],
+                                 capture_output=True, text=True)
         if result.returncode != 0:
             pytest.fail(f"Failed to install: {result.stderr}")
         try:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,8 +1,6 @@
 import pytest
 
 from .utils import CookiecutterMDAKit, DependencyType
-import subprocess
-import sys
 
 class TestAnalysis:
 

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "{{cookiecutter.package_name}}"
+name = "{{cookiecutter.repo_name}}"
 description = "{{cookiecutter.description}}"
 license = {{ "{" }}file = "LICENSE" {{ "}" }}
 authors = [
@@ -42,8 +42,8 @@ doc = [
 # source = "https://github.com/{{cookiecutter.github_url}}"
 # documentation = "https://{{cookiecutter.repo_name}}.readthedocs.io"
 
-[tool.setuptools]
-packages = ["{{cookiecutter.package_name}}"]
+[tool.setuptools.packages.find]
+include = ["{{cookiecutter.package_name}}"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "{{cookiecutter.repo_name}}"
+name = "{{cookiecutter.package_name}}"
 description = "{{cookiecutter.description}}"
 license = {{ "{" }}file = "LICENSE" {{ "}" }}
 authors = [
@@ -43,12 +43,12 @@ doc = [
 # documentation = "https://{{cookiecutter.repo_name}}.readthedocs.io"
 
 [tool.setuptools]
-py-modules = []
+packages = ["{{cookiecutter.package_name}}"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
 testpaths = [
-    "{{cookiecutter.repo_name}}/tests",
+    "{{cookiecutter.package_name}}/tests",
 ]
 
 [tool.black]

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/__init__.py
@@ -6,4 +6,4 @@
 # Add imports here
 from importlib.metadata import version
 
-__version__ = version("{{cookiecutter.package_name}}")
+__version__ = version("{{cookiecutter.repo_name}}")


### PR DESCRIPTION
Fixes #113

Changes made in this Pull Request:
 - Changed pyproject.toml to use packagename instead of reponame for tests
 - Added setuptools directive to fix installation issue

I used a repo which contains multiple packages as a model for these changes: https://github.com/Gallopsled/pwntools
The idea is that if the repo name differs from the package name, you should be able to do 
```
pip show <repo_name> 
```
But not be able to import the package using the reponame. You must import using
```
import <package_name>
```
However, this leaves the issue of versioning, since the package_name's `__init__` method uses (AFAIK) the version is associated with the repo_name. I set the package's version to use the version associated with repo_name by default and the user will have to be responsible for changing this if it doesn't apply (in the case they have two packages in the repo that are both different versions)

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG.md updated?
 - [x] AUTHORS.md updated?
 - [x] Issue raised/referenced?
