### PR TITLE
Remove x86 pin setup-miniconda

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
@@ -65,7 +65,6 @@ jobs:
         python-version: {{ '${{ matrix.python-version }}' }}
         environment-file: devtools/conda-envs/test_env.yaml
         add-pip-as-python-dependency: true
-        architecture: x64
 {% if cookiecutter.__dependency_source == 'conda-forge' %}
         miniforge-variant: Mambaforge
         use-mamba: true


### PR DESCRIPTION
This seems to be forcing some kind of x86 compatibility build of Python on osx-arm64, removing makes the action pick up the right installer.

You can see this action for more details: https://github.com/MDAnalysis/mdahole2/actions/runs/10024096447/job/27705759572