### PR TITLE
Update readthedocs to have config key

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -3,7 +3,7 @@
 version: 2
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 build:
   os: ubuntu-22.04

--- a/{{cookiecutter.repo_name}}/readthedocs.yaml
+++ b/{{cookiecutter.repo_name}}/readthedocs.yaml
@@ -4,7 +4,7 @@ version: 2
 
 # Sphinx configuration
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 # Uncomment the following lines to enable MkDocs configuration
 # mkdocs:


### PR DESCRIPTION
Fixes #150 

Changes made in this Pull Request:
 - Updates config key in both cookiecutter repo, and cookie repo
 - Checked RTD config file and ubuntu-22.04 is still the recommended/example OS


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG.md updated?
 - [ ] AUTHORS.md updated?
 - [ ] Issue raised/referenced?
