### PR TITLE
Fix: build docs by setting repo_name as project_name to 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -28,3 +28,6 @@ The rules for this file:
 
 **2024**
 - Lawson Woods \<@ljwoods2\>
+
+**2024**
+- Estefania Barreto-Ojeda \<@ojeda-e\>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The rules for this file:
 - RMeli
 - orbeckst
 - ljwoods2
+- ojeda-e
 
 ### Added
 <!-- New added features -->
@@ -42,6 +43,7 @@ The rules for this file:
 
 ### Fixed
 <!-- Bug fixes -->
+- Build docs by fixing `repo_name` cookicutter cli (Issue #157, PR #158)
 - Updated mambaforge version in `readthedocs.yaml` (Issue #132, PR #133)
 - Switched deprecated pkg_resources to use importlib (PR #122, Issue #121)
 - Fixed pypi_check with lowercase (PR #118, Issue #112)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ The rules for this file:
 
 ### Fixed
 <!-- Bug fixes -->
-- Build docs by fixing `repo_name` cookicutter cli (Issue #157, PR #158)
+- Build docs by fixing `repo_name` cookiecutter cli (Issue #157, PR #158)
 - Updated mambaforge version in `readthedocs.yaml` (Issue #132, PR #133)
 - Switched deprecated pkg_resources to use importlib (PR #122, Issue #121)
 - Fixed pypi_check with lowercase (PR #118, Issue #112)

--- a/docs/scripts/generate_cookiecutter_cli.py
+++ b/docs/scripts/generate_cookiecutter_cli.py
@@ -13,6 +13,11 @@ COOKIECUTTER_PATH = abs_filepath.parent.parent.parent
 GENERATED_PATH = COOKIECUTTER_PATH / "docs" / "source" / "generated"
 
 
+def repo_name_from_project_name(project_name: str) -> str:
+    """Same reference name as in ``repo_name`` default in ``cookiecutter.json``."""
+    return project_name.lower().replace(" ", "_").replace("-", "_")
+
+
 def flatten_dict(dct, key=tuple()):
     """Turn a nested dict into a flat dict, with keys as tuples."""
     for k, v in dct.items():
@@ -78,7 +83,8 @@ class FileDescriptions:
 class ExampleRepositoryDocumentation:
 
     def __init__(self):
-        self.repo_name = "example-repository"
+        self.project_name = "My Project Name"
+        self.repo_name = repo_name_from_project_name(self.project_name)
         self.package_name = "package_name"
         self.example_repo_path = GENERATED_PATH / self.repo_name
         self.cookiecutter_cli_log = GENERATED_PATH / "cookiecutter_cli.log"
@@ -86,7 +92,7 @@ class ExampleRepositoryDocumentation:
 
     def generate_cli_output(self) -> str:
         inputs = [
-            "My Project Name",  # project_name
+            self.project_name,  # project_name
             self.repo_name,  # repo_name
             self.package_name,  # package_name
             "A package to do MD analysis",  # description
@@ -97,8 +103,6 @@ class ExampleRepositoryDocumentation:
             "",  # dependency_source
             "",  # include_ReadTheDocs
             "MyAnalysisClass",  # template_analysis_class
-            ""
-            ""
         ]
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,7 @@ language = "en"
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
 exclude_patterns = ["_build", "Thumbs.db",
-                    ".DS_Store", "generated/example-repository/*"]
+                    ".DS_Store", "generated/my_project_name/*"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,7 @@ language = "en"
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
 exclude_patterns = ["_build", "Thumbs.db",
-                    ".DS_Store", "generated/my_project_name/*"]
+                    ".DS_Store", "generated/project_name/*"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -36,7 +36,7 @@ The :ref:`options-label` section below provides more details on these options,
 default values (if applicable), what they mean, and what they affect.
 
 Running the cookiecutter will the above responses will generate the following 
-output skeleton, (as well as initialise a git repository `example-repository`, 
+output skeleton, (as well as initialise a git repository `my_project_name`, 
 make an initial commit, and add a  "0.0.0" tag to set the initial version):
 
 .. literalinclude:: generated/cookie_tree.txt

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -36,7 +36,7 @@ The :ref:`options-label` section below provides more details on these options,
 default values (if applicable), what they mean, and what they affect.
 
 Running the cookiecutter will the above responses will generate the following 
-output skeleton, (as well as initialise a git repository `my_project_name`, 
+output skeleton, (as well as initialise a git repository `project_name`, 
 make an initial commit, and add a  "0.0.0" tag to set the initial version):
 
 .. literalinclude:: generated/cookie_tree.txt

--- a/tests/test_generate_cookiecutter_cli.py
+++ b/tests/test_generate_cookiecutter_cli.py
@@ -1,0 +1,27 @@
+"""Tests for docs/scripts/generate_cookiecutter_cli helpers."""
+
+import pathlib
+import sys
+
+import pytest
+
+_DOCS_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "docs" / "scripts"
+sys.path.insert(0, str(_DOCS_SCRIPTS))
+
+from generate_cookiecutter_cli import repo_name_from_project_name  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("project_name", "expected_repo_name"),
+    [
+        ("A Project Name", "a_project_name"),
+        ("same_name_as_project", "same_name_as_project"),
+        ("Test-Project Name", "test_project_name"),
+    ],
+)
+def test_repo_name_from_project_name_matches_cookiecutter_default(
+    project_name: str,
+    expected_repo_name: str,
+) -> None:
+    """Mirrors ``repo_name`` in cookiecutter.json (slug from ``project_name``)."""
+    assert repo_name_from_project_name(project_name) == expected_repo_name


### PR DESCRIPTION
Fixes #157 

Changes made in this Pull Request:
 - Changes `repo_name` from `"example-repository"` to `project_name`.


PR Checklist
------------
 - [x] Tests?
 - [N/A] Docs?
 - [x] CHANGELOG.md updated?
 - [x] AUTHORS.md updated?
 - [x] Issue raised/referenced?
