### PR TITLE
Enhance: Add dummy function w/ parametrized tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The rules for this file:
 
 ### Added
 <!-- New added features -->
+- Add example of API import with unit tests using pytest parametrize (PR #161)
 - Extend license options to MIT (default), GPLv3+, BSD 3-clause and Apache 2 (PR #156)
 - Add black configurartion to `pyproject.toml` (Issue #73, PR #75)
 - Cookiecutter version dependency (Issue #33, PR #46)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/example_api.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/example_api.py
@@ -1,0 +1,3 @@
+def example_function(number: float) -> float:
+    """Return `2*number`. This is and example for tests."""
+    return 2 * number

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/tests/test_{{cookiecutter.package_name}}.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/tests/test_{{cookiecutter.package_name}}.py
@@ -6,6 +6,7 @@ Unit and regression test for the {{cookiecutter.package_name}} package.
 import sys
 import pytest
 import {{cookiecutter.package_name}}
+from {{cookiecutter.package_name}}.example_api import example_function
 
 
 def test_{{cookiecutter.package_name}}_imported():
@@ -17,3 +18,16 @@ def test_mdanalysis_logo_length(mdanalysis_logo_text):
     """Example test using a fixture defined in conftest.py"""
     logo_lines = mdanalysis_logo_text.split("\n")
     assert len(logo_lines) == 46, "Logo file does not have 46 lines!"
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, 0),
+        (1, 2),
+        (-5, -25),
+        (1.5, 3.0),
+        (-2.0, -4.0)
+    ],
+)
+def test_double_value(value, expected):
+    assert example_function(value) == expected

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/tests/test_{{cookiecutter.package_name}}.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/tests/test_{{cookiecutter.package_name}}.py
@@ -24,7 +24,7 @@ def test_mdanalysis_logo_length(mdanalysis_logo_text):
     [
         (0, 0),
         (1, 2),
-        (-5, -25),
+        (-5, -10),
         (1.5, 3.0),
         (-2.0, -4.0)
     ],


### PR DESCRIPTION
Fixes #35, with the following nuances:
- the `test_PROJECT.py` referenced in the issue, that shows how to use files inside `data/`, is currently `{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/tests/conftest.py` 
- the issue also makes reference to a `canvas`, but it isn't in the repo either.
 
Changes made in this Pull Request:
 - Created new file called `example_api.py` with  a dummy function that doubles a number.
 - Updated tests with import and pytest parametrize for several cases in `test_double_value`.


PR Checklist
------------
 - [x] Tests?
 - [N/A] Docs?
 - [x] CHANGELOG.md updated?
 - [N/A] AUTHORS.md updated?
 - [x] Issue raised/referenced?
