### PR TITLE
Revert back to default mamba installation

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/{{cookiecutter._ci_name}}.yaml
@@ -75,7 +75,7 @@ jobs:
       with:
         version: {{ "${{ matrix.mdanalysis-version }}" }}
         install-tests: false
-        installer: {% if cookiecutter.__dependency_source == 'conda-forge' %} conda {% else %} pip {% endif %}
+        installer: {% if cookiecutter.__dependency_source == 'conda-forge' %} mamba {% else %} pip {% endif %}
         shell: bash {% if cookiecutter.__dependency_source != 'pip' %} -l {0} {% endif %}
       
     - name: Install package


### PR DESCRIPTION
Fixes #162 

There was a temporary change to conda. This PR reverts it.

Changes made in this Pull Request:
 - Set mamba as installer when dependency source is `conda-forge`.


PR Checklist
------------
 - [N/A] Tests?
 - [N/A] Docs?
 - [N/A] CHANGELOG.md updated?
 - [N/A] AUTHORS.md updated?
 - [x] Issue raised/referenced?
